### PR TITLE
Handle when line delimiters contain a carriage return

### DIFF
--- a/org.eclipse.mcp/src/org/eclipse/mcp/internal/preferences/AcpGeneralPreferencePage.java
+++ b/org.eclipse.mcp/src/org/eclipse/mcp/internal/preferences/AcpGeneralPreferencePage.java
@@ -117,8 +117,7 @@ public class AcpGeneralPreferencePage extends PreferencePage
 		// Handle when line delimiters contain a carriage return character
 		preference = preference.replaceAll("\r\n", "\n");
 		
-		store.setValue(geminiPreferenceId, gemini.getText());;
-
+		store.setValue(geminiPreferenceId, preference);
 	}
 
 	@Override


### PR DESCRIPTION
The PR handles the case in windows where the Agent CLIs > Gemini CLI: preference is interpreted as having "\r\n" as a line break delimiter, where previously the preferences were split by "\n".

This would lead to the following error, because after splitting by "\n", the lines would still contain a carriage return at the end:

<img width="1762" height="195" alt="image" src="https://github.com/user-attachments/assets/f92d7ef4-5844-4ee8-8619-ef9a770039c8" />

(Notice the quotes on the following line after node.exe)