### PR TITLE
Windows npm auto install update and run gemini

### DIFF
--- a/org.eclipse.mcp/src/org/eclipse/mcp/acp/agent/GeminiService.java
+++ b/org.eclipse.mcp/src/org/eclipse/mcp/acp/agent/GeminiService.java
@@ -59,8 +59,8 @@ public class GeminiService extends AbstractService {
 			}
 			
 			File agentsNodeDir = getAgentsNodeDirectory();
-
-			ProcessBuilder pb = NodeJSManager.prepareNPMProcessBuilder("i", "@google/gemini-cli", "--prefix", agentsNodeDir.getPath());
+			
+			ProcessBuilder pb = NodeJSManager.prepareNPMProcessBuilder("i", "@google/gemini-cli", "--prefix", agentsNodeDir.getAbsolutePath());
 			pb.directory(agentsNodeDir);
 			String path = pb.environment().get("PATH");
 			path = NodeJSManager.getNodeJsLocation().getParentFile().getAbsolutePath() + 


### PR DESCRIPTION
This PR adds the "--prefix" argument to override the node module install location so that Gemini is installed in the ".eclipseagents" folder in the user's home directory.

This also cleans up whitespace in the GeminiService and removes the unused Map and the reference to java.util.Map.

The only logical code change in this file should be the following line:

`ProcessBuilder pb = NodeJSManager.prepareNPMProcessBuilder("i", "@google/gemini-cli", "--prefix", agentsNodeDir.getPath());`

When reviewing the PR, it would be good to verify that it's still installed in the correct location on Mac after the change was introduced.
