### PR TITLE
fix test dependency on service loading of mcp jackson

### DIFF
--- a/org.eclipse.agents.test/META-INF/services/io.modelcontextprotocol.json.McpJsonMapperSupplier
+++ b/org.eclipse.agents.test/META-INF/services/io.modelcontextprotocol.json.McpJsonMapperSupplier
@@ -1,0 +1,1 @@
+io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapperSupplier

--- a/org.eclipse.agents.test/META-INF/services/io.modelcontextprotocol.json.schema.JsonSchemaValidatorSupplier
+++ b/org.eclipse.agents.test/META-INF/services/io.modelcontextprotocol.json.schema.JsonSchemaValidatorSupplier
@@ -1,0 +1,1 @@
+io.modelcontextprotocol.json.schema.jackson.JacksonJsonSchemaValidatorSupplier


### PR DESCRIPTION
The two plugin tests were getting similar errors to:
https://github.com/modelcontextprotocol/java-sdk/issues/574

The fix seems to be to add a services folder to META-INF defining the default implementation classes for two interfaces so that MCP uses them.  The issue doesnt seem to occur in the main agents plugin, but maybe pops up when re-using exported plugins due to differences in OSGI behavior...