### PR TITLE
Open links externally

### DIFF
--- a/org.eclipse.agents/src/org/eclipse/agents/chat/ChatBrowser.java
+++ b/org.eclipse.agents/src/org/eclipse/agents/chat/ChatBrowser.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
This PR fixes an issue where clicking any link in the chat would navigate the chat to the new destination, with no ability to navigate back to the chat. This works by setting target="_blank" in the anchor tags, and the OpenWindowListener needed to be removed from the AcpProwser.

Also, inconsistent tabs/spaces were fixed in AcpBrowser.