### PR TITLE
Fix for 'null is not an object' error getting logged

### DIFF
--- a/org.eclipse.agents/chat/session.js
+++ b/org.eclipse.agents/chat/session.js
@@ -83,8 +83,16 @@ function acceptSessionToolCall(toolCallId, title, kind, status) {
 
 
 function acceptSessionToolCallUpdate(toolCallId, status) {
-    getTurn().querySelector('tool-call#' + toolCallId).updateStatus(status);
-	scrollToBottom();
+	let toolCall = getTurn().querySelector('tool-call#' + toolCallId);
+	if (toolCall == null) {
+		// TODO: tool-call is currently not created for permission requests
+		// may need to look up the tool call for permission requests differently
+	}
+	
+	if (toolCall != null) {
+		toolCall.updateStatus(status);
+		scrollToBottom();
+	}
 }
 
 


### PR DESCRIPTION
This resolves issue #33 :

tool-call updates are getting requested when accepting or rejecting a permission request, when the tool calls haven't been created for permission requests.

The remainder of the logic for updating will be implemented as part of the tool usage approval workflow.