### PR TITLE
update target dependencies

### DIFF
--- a/target-platforms/latest.target
+++ b/target-platforms/latest.target
@@ -23,6 +23,11 @@
 			<unit id="org.eclipse.ui.navigator" version="0.0.0"/>
 			<unit id="org.junit" version="0.0.0"/>
 			<unit id="org.eclipse.jdt.core" version="0.0.0"/>
+			<unit id="org.eclipse.team.core" version="0.0.0"/>
+			<unit id="org.eclipse.team.ui" version="0.0.0"/>
+			<unit id="org.eclipse.ltk.core.refactoring" version="0.0.0"/>
+			<unit id="org.eclipse.ui.forms" version="0.0.0"/>
+			<unit id="org.eclipse.core.expressions" version="0.0.0"/>
 			<unit id="junit-jupiter-api" version="0.0.0"/>
 		</location>
 


### PR DESCRIPTION
Fix build failure:

[INFO] Reactor Summary for org.eclipse.eclipse-agents 1.0.0-SNAPSHOT:
[INFO] 
[INFO] org.eclipse.eclipse-agents ......................... SUCCESS [  2.541 s]
[INFO] org.eclipse.agents ................................. FAILURE [  7.658 s]
[INFO] org.eclipse.agents.feature ......................... SKIPPED
[INFO] org.eclipse.agents.test ............................ SKIPPED
[INFO] org.eclipse.agents.update-site ..................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:17 min (Wall Clock)
[INFO] Finished at: 2026-01-27T16:24:16-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Cannot resolve dependencies of project org.eclipse:org.eclipse.agents:eclipse-plugin:1.0.0-SNAPSHOT
[ERROR]  with context {osgi.os=win32, osgi.ws=win32, org.eclipse.update.install.features=true, osgi.arch=x86_64, org.eclipse.update.install.sources=true}
[ERROR]   Software being installed: org.eclipse.agents 1.0.0.qualifier
[ERROR]   Missing requirement: org.eclipse.agents 1.0.0.qualifier requires 'osgi.bundle; org.eclipse.team.core 0.0.0' but it could not be found: See log for details
[ERROR] -> [Help 1]
