### PR TITLE
Custom agents support

### DIFF
--- a/org.eclipse.agents/plugin.xml
+++ b/org.eclipse.agents/plugin.xml
@@ -129,6 +129,15 @@
 			<keywordReference id="org.eclipse.agents.keyword.google" />
 			<keywordReference id="org.eclipse.agents.keyword.gemini" />
 		</page>
+		<page
+			id="org.eclipse.agents.preferences.services.custom"
+			name="Custom Agents"
+			category="org.eclipse.agents.preferences.services"
+			class="org.eclipse.agents.preferences.AcpCustomAgentsPreferencePage">
+			<keywordReference id="org.eclipse.agents.keyword.acp" />
+			<keywordReference id="org.eclipse.agents.keyword.agent" />
+			<keywordReference id="org.eclipse.agents.keyword.coding" />
+		</page>
 	</extension>
 
 	<extension point="org.eclipse.core.runtime.preferences">

--- a/org.eclipse.agents/src/org/eclipse/agents/chat/controller/AgentController.java
+++ b/org.eclipse.agents/src/org/eclipse/agents/chat/controller/AgentController.java
@@ -13,10 +13,15 @@
  *******************************************************************************/
 package org.eclipse.agents.chat.controller;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.eclipse.agents.Activator;
+import org.eclipse.agents.preferences.IPreferenceConstants;
+import org.eclipse.agents.services.agent.CustomAgentService;
 import org.eclipse.agents.services.agent.GeminiService;
 import org.eclipse.agents.services.agent.IAgentService;
 import org.eclipse.agents.services.protocol.AcpSchema.AgentNotification;
@@ -53,6 +58,11 @@ import org.eclipse.agents.services.protocol.AcpSchema.WriteTextFileRequest;
 import org.eclipse.agents.services.protocol.AcpSchema.WriteTextFileResponse;
 import org.eclipse.core.runtime.ListenerList;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 public class AgentController {
 
 	private static AgentController instance;
@@ -66,22 +76,85 @@ public class AgentController {
 		instance = new AgentController();
 	}
 	
-	IAgentService[] agentServices;
+	List<IAgentService> agentServices;
 	private AgentController() {
-		agentServices = new IAgentService[] { 
-			new GeminiService()
-//			new GooseService()
-		};
+		agentServices = new ArrayList<IAgentService>();
+		agentServices.add(new GeminiService());
 		agentListeners = new ListenerList<IAgentServiceListener>();
 		sesionListeners = new  ListenerList<ISessionListener>();
+		loadCustomAgents();
 	}
-	
+
 	public static AgentController instance() {
 		return instance;
 	}
-	
+
 	public IAgentService[] getAgents() {
-		return agentServices;
+		return agentServices.toArray(new IAgentService[agentServices.size()]);
+	}
+
+	public void addAgent(IAgentService agent) {
+		agentServices.add(agent);
+	}
+
+	public void removeAgent(IAgentService agent) {
+		if (agent.isRunning()) {
+			agent.stop();
+		}
+		if (agent.isScheduled()) {
+			agent.unschedule();
+		}
+		agentServices.remove(agent);
+	}
+
+	public void refreshCustomAgents() {
+		// Stop and remove existing custom agents
+		List<IAgentService> toRemove = new ArrayList<IAgentService>();
+		for (IAgentService agent : agentServices) {
+			if (agent instanceof CustomAgentService) {
+				if (agent.isRunning()) {
+					agent.stop();
+				}
+				if (agent.isScheduled()) {
+					agent.unschedule();
+				}
+				toRemove.add(agent);
+			}
+		}
+		agentServices.removeAll(toRemove);
+		// Reload from preferences
+		loadCustomAgents();
+	}
+
+	private void loadCustomAgents() {
+		try {
+			String json = Activator.getDefault().getPreferenceStore().getString(IPreferenceConstants.P_ACP_CUSTOM_AGENTS);
+			if (json == null || json.isEmpty()) {
+				return;
+			}
+			Gson gson = new Gson();
+			JsonArray array = gson.fromJson(json, JsonArray.class);
+			if (array == null) {
+				return;
+			}
+			for (JsonElement element : array) {
+				JsonObject obj = element.getAsJsonObject();
+				String id = obj.get("id").getAsString();
+				String name = obj.get("name").getAsString();
+				JsonArray cmdArray = obj.getAsJsonArray("command");
+				String[] command = new String[cmdArray.size()];
+				for (int i = 0; i < cmdArray.size(); i++) {
+					command[i] = cmdArray.get(i).getAsString();
+				}
+				String workingDirectory = null;
+				if (obj.has("workingDirectory") && !obj.get("workingDirectory").isJsonNull()) {
+					workingDirectory = obj.get("workingDirectory").getAsString();
+				}
+				agentServices.add(new CustomAgentService(id, name, command, workingDirectory));
+			}
+		} catch (Exception e) {
+			// If preferences are corrupt, just skip loading custom agents
+		}
 	}
 	
 	public static void putSession(String sessionId, SessionController controller) {

--- a/org.eclipse.agents/src/org/eclipse/agents/chat/controller/StartSessionJob.java
+++ b/org.eclipse.agents/src/org/eclipse/agents/chat/controller/StartSessionJob.java
@@ -64,10 +64,10 @@ public class StartSessionJob extends Job {
 			
 			boolean supportsSseMcp = initializeResponse.agentCapabilities() != null &&
 					initializeResponse.agentCapabilities().mcpCapabilities() != null &&
-							initializeResponse.agentCapabilities().mcpCapabilities().sse();
-			
+							Boolean.TRUE.equals(initializeResponse.agentCapabilities().mcpCapabilities().sse());
+
 			boolean supportsLoadSession = initializeResponse.agentCapabilities() != null &&
-					initializeResponse.agentCapabilities().loadSession();
+					Boolean.TRUE.equals(initializeResponse.agentCapabilities().loadSession());
 			
 			if (oldSessionId != null && supportsLoadSession) {
 

--- a/org.eclipse.agents/src/org/eclipse/agents/chat/toolbar/ToolbarAgentSelector.java
+++ b/org.eclipse.agents/src/org/eclipse/agents/chat/toolbar/ToolbarAgentSelector.java
@@ -24,19 +24,16 @@ import org.eclipse.jface.action.MenuManager;
 
 public class ToolbarAgentSelector extends AbstractDynamicToolbarDropdown {
 
-	List<SelectAgentAction> actions;
-	
 	public ToolbarAgentSelector(ChatView view) {
 		super("Coding Agent...", "Select a coding agent", view);
-		
-		actions = new ArrayList<SelectAgentAction>();
-		for (IAgentService agent: AgentController.instance().getAgents()) {
-			actions.add(new SelectAgentAction(view, agent, this));
-		}
 	}
 
 	@Override
 	protected void fillMenu(MenuManager menuManager) {
+		List<SelectAgentAction> actions = new ArrayList<SelectAgentAction>();
+		for (IAgentService agent: AgentController.instance().getAgents()) {
+			actions.add(new SelectAgentAction(getView(), agent, this));
+		}
 		for (SelectAgentAction action: actions) {
 			menuManager.add(action);
 			action.setChecked(action.getAgent() ==  getView().getActiveAgent());

--- a/org.eclipse.agents/src/org/eclipse/agents/preferences/AcpCustomAgentsPreferencePage.java
+++ b/org.eclipse.agents/src/org/eclipse/agents/preferences/AcpCustomAgentsPreferencePage.java
@@ -1,0 +1,475 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.agents.preferences;
+
+import org.eclipse.agents.Activator;
+import org.eclipse.agents.chat.controller.AgentController;
+import org.eclipse.agents.chat.controller.IAgentServiceListener;
+import org.eclipse.agents.services.agent.CustomAgentService;
+import org.eclipse.agents.services.agent.IAgentService;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferencePage;
+import org.eclipse.jface.window.Window;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.TableItem;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.eclipse.ui.PlatformUI;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class AcpCustomAgentsPreferencePage extends PreferencePage implements
+		IAgentServiceListener, IPreferenceConstants, IWorkbenchPreferencePage {
+
+	private Table agentTable;
+	private Button addButton;
+	private Button editButton;
+	private Button removeButton;
+	private Button startButton;
+	private Button stopButton;
+	private Text statusText;
+
+	// Working copy of agent configs (edited in UI, saved on OK)
+	private JsonArray agentConfigs;
+
+	public AcpCustomAgentsPreferencePage() {
+		super();
+	}
+
+	@Override
+	public void init(IWorkbench workbench) {
+		setPreferenceStore(Activator.getDefault().getPreferenceStore());
+		AgentController.instance().addAgentListener(this);
+	}
+
+	@Override
+	protected Control createContents(Composite ancestor) {
+		Composite parent = new Composite(ancestor, SWT.NONE);
+		GridLayout layout = new GridLayout();
+		layout.numColumns = 2;
+		layout.marginHeight = 0;
+		layout.marginWidth = 0;
+		parent.setLayout(layout);
+
+		Label instructions = new Label(parent, SWT.WRAP);
+		instructions.setText("Add and manage custom third-party ACP agents.");
+		GridData gd = new GridData(SWT.FILL, SWT.BEGINNING, true, false, 2, 1);
+		gd.widthHint = convertWidthInCharsToPixels(80);
+		instructions.setLayoutData(gd);
+
+		// Agent table
+		agentTable = new Table(parent, SWT.BORDER | SWT.SINGLE | SWT.FULL_SELECTION);
+		agentTable.setHeaderVisible(true);
+		agentTable.setLinesVisible(true);
+		gd = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 6);
+		gd.heightHint = 150;
+		agentTable.setLayoutData(gd);
+
+		TableColumn nameColumn = new TableColumn(agentTable, SWT.NONE);
+		nameColumn.setText("Name");
+		nameColumn.setWidth(200);
+
+		TableColumn commandColumn = new TableColumn(agentTable, SWT.NONE);
+		commandColumn.setText("Command");
+		commandColumn.setWidth(300);
+
+		agentTable.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				updateEnablement();
+				updateStatus();
+			}
+		});
+
+		// Buttons
+		addButton = new Button(parent, SWT.PUSH);
+		addButton.setText("Add...");
+		addButton.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, false, false));
+		addButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				handleAdd();
+			}
+		});
+
+		editButton = new Button(parent, SWT.PUSH);
+		editButton.setText("Edit...");
+		editButton.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, false, false));
+		editButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				handleEdit();
+			}
+		});
+
+		removeButton = new Button(parent, SWT.PUSH);
+		removeButton.setText("Remove");
+		removeButton.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, false, false));
+		removeButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				handleRemove();
+			}
+		});
+
+		startButton = new Button(parent, SWT.PUSH);
+		startButton.setText("Start");
+		startButton.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, false, false));
+		startButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				handleStart();
+			}
+		});
+
+		stopButton = new Button(parent, SWT.PUSH);
+		stopButton.setText("Stop");
+		stopButton.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, false, false));
+		stopButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				handleStop();
+			}
+		});
+
+		// Status area
+		Label statusLabel = new Label(parent, SWT.NONE);
+		statusLabel.setText("Status:");
+		statusLabel.setLayoutData(new GridData(SWT.BEGINNING, SWT.BEGINNING, true, false, 2, 1));
+
+		statusText = new Text(parent, SWT.MULTI | SWT.BORDER | SWT.READ_ONLY);
+		gd = new GridData(SWT.FILL, SWT.BEGINNING, true, false, 2, 1);
+		gd.heightHint = 60;
+		statusText.setLayoutData(gd);
+
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(parent,
+				"org.eclipse.agents.preferences.AcpCustomAgentsPreferencePage"); //$NON-NLS-1$
+
+		loadPreferences();
+		refreshTable();
+		updateEnablement();
+
+		return parent;
+	}
+
+	private void loadPreferences() {
+		IPreferenceStore store = getPreferenceStore();
+		String json = store.getString(P_ACP_CUSTOM_AGENTS);
+		if (json == null || json.isEmpty()) {
+			json = "[]";
+		}
+		Gson gson = new Gson();
+		agentConfigs = gson.fromJson(json, JsonArray.class);
+		if (agentConfigs == null) {
+			agentConfigs = new JsonArray();
+		}
+	}
+
+	private void refreshTable() {
+		agentTable.removeAll();
+		for (JsonElement element : agentConfigs) {
+			JsonObject obj = element.getAsJsonObject();
+			TableItem item = new TableItem(agentTable, SWT.NONE);
+			item.setText(0, obj.get("name").getAsString());
+			JsonArray cmdArray = obj.getAsJsonArray("command");
+			StringBuilder cmdStr = new StringBuilder();
+			for (int i = 0; i < cmdArray.size(); i++) {
+				if (i > 0) cmdStr.append(" ");
+				cmdStr.append(cmdArray.get(i).getAsString());
+			}
+			item.setText(1, cmdStr.toString());
+			item.setData(obj.get("id").getAsString());
+		}
+	}
+
+	private void updateEnablement() {
+		int selIndex = agentTable.getSelectionIndex();
+		boolean hasSelection = selIndex >= 0;
+		editButton.setEnabled(hasSelection);
+		removeButton.setEnabled(hasSelection);
+
+		if (hasSelection) {
+			String agentId = (String) agentTable.getItem(selIndex).getData();
+			IAgentService service = findRunningService(agentId);
+			startButton.setEnabled(service == null || (!service.isRunning() && !service.isScheduled()));
+			stopButton.setEnabled(service != null && (service.isRunning() || service.isScheduled()));
+		} else {
+			startButton.setEnabled(false);
+			stopButton.setEnabled(false);
+		}
+	}
+
+	private void updateStatus() {
+		int selIndex = agentTable.getSelectionIndex();
+		if (selIndex < 0) {
+			statusText.setText("");
+			return;
+		}
+
+		String agentId = (String) agentTable.getItem(selIndex).getData();
+		IAgentService service = findRunningService(agentId);
+		if (service == null) {
+			statusText.setText("Stopped");
+		} else if (service.isRunning()) {
+			statusText.setText("Running");
+		} else if (service.isScheduled()) {
+			statusText.setText("Starting");
+		} else {
+			statusText.setText("Stopped");
+		}
+	}
+
+	private IAgentService findRunningService(String agentId) {
+		for (IAgentService service : AgentController.instance().getAgents()) {
+			if (service instanceof CustomAgentService && service.getId().equals(agentId)) {
+				return service;
+			}
+		}
+		return null;
+	}
+
+	private void handleAdd() {
+		CustomAgentDialog dialog = new CustomAgentDialog(getShell());
+		if (dialog.open() == Window.OK) {
+			String id = "agent-" + System.currentTimeMillis();
+			String name = dialog.getAgentName();
+			String command = dialog.getCommand();
+			String workingDir = dialog.getWorkingDirectory();
+
+			JsonObject obj = new JsonObject();
+			obj.addProperty("id", id);
+			obj.addProperty("name", name);
+			String[] cmdParts = command.split("\n");
+			JsonArray cmdArray = new JsonArray();
+			for (String part : cmdParts) {
+				String trimmed = part.trim();
+				if (!trimmed.isEmpty()) {
+					cmdArray.add(trimmed);
+				}
+			}
+			obj.add("command", cmdArray);
+			if (workingDir != null && !workingDir.isEmpty()) {
+				obj.addProperty("workingDirectory", workingDir);
+			}
+			agentConfigs.add(obj);
+			refreshTable();
+			updateEnablement();
+		}
+	}
+
+	private void handleEdit() {
+		int selIndex = agentTable.getSelectionIndex();
+		if (selIndex < 0) return;
+
+		JsonObject obj = agentConfigs.get(selIndex).getAsJsonObject();
+		String currentName = obj.get("name").getAsString();
+		JsonArray cmdArray = obj.getAsJsonArray("command");
+		StringBuilder cmdStr = new StringBuilder();
+		for (int i = 0; i < cmdArray.size(); i++) {
+			if (i > 0) cmdStr.append("\n");
+			cmdStr.append(cmdArray.get(i).getAsString());
+		}
+		String currentWorkDir = "";
+		if (obj.has("workingDirectory") && !obj.get("workingDirectory").isJsonNull()) {
+			currentWorkDir = obj.get("workingDirectory").getAsString();
+		}
+
+		CustomAgentDialog dialog = new CustomAgentDialog(getShell(), currentName, cmdStr.toString(), currentWorkDir);
+		if (dialog.open() == Window.OK) {
+			obj.addProperty("name", dialog.getAgentName());
+			String command = dialog.getCommand();
+			String[] cmdParts = command.split("\n");
+			JsonArray newCmdArray = new JsonArray();
+			for (String part : cmdParts) {
+				String trimmed = part.trim();
+				if (!trimmed.isEmpty()) {
+					newCmdArray.add(trimmed);
+				}
+			}
+			obj.add("command", newCmdArray);
+			String workingDir = dialog.getWorkingDirectory();
+			if (workingDir != null && !workingDir.isEmpty()) {
+				obj.addProperty("workingDirectory", workingDir);
+			} else {
+				obj.remove("workingDirectory");
+			}
+			refreshTable();
+			agentTable.setSelection(selIndex);
+			updateEnablement();
+		}
+	}
+
+	private void handleRemove() {
+		int selIndex = agentTable.getSelectionIndex();
+		if (selIndex < 0) return;
+
+		String name = agentTable.getItem(selIndex).getText(0);
+		boolean confirm = MessageDialog.openConfirm(getShell(), "Remove Custom Agent",
+				"Are you sure you want to remove the agent '" + name + "'?");
+		if (confirm) {
+			String agentId = (String) agentTable.getItem(selIndex).getData();
+			// Stop the agent if running
+			IAgentService service = findRunningService(agentId);
+			if (service != null) {
+				AgentController.instance().removeAgent(service);
+			}
+			agentConfigs.remove(selIndex);
+			refreshTable();
+			updateEnablement();
+			statusText.setText("");
+		}
+	}
+
+	private void handleStart() {
+		int selIndex = agentTable.getSelectionIndex();
+		if (selIndex < 0) return;
+
+		String agentId = (String) agentTable.getItem(selIndex).getData();
+		IAgentService service = findRunningService(agentId);
+		if (service != null) {
+			service.schedule();
+		} else {
+			// Agent not yet added to controller - need to save first, then sync
+			savePreferences();
+			AgentController.instance().refreshCustomAgents();
+			service = findRunningService(agentId);
+			if (service != null) {
+				service.schedule();
+			}
+		}
+		updateEnablement();
+		updateStatus();
+	}
+
+	private void handleStop() {
+		int selIndex = agentTable.getSelectionIndex();
+		if (selIndex < 0) return;
+
+		String agentId = (String) agentTable.getItem(selIndex).getData();
+		IAgentService service = findRunningService(agentId);
+		if (service != null) {
+			service.stop();
+			service.unschedule();
+		}
+		updateEnablement();
+		updateStatus();
+	}
+
+	private void savePreferences() {
+		IPreferenceStore store = getPreferenceStore();
+		Gson gson = new Gson();
+		store.setValue(P_ACP_CUSTOM_AGENTS, gson.toJson(agentConfigs));
+	}
+
+	@Override
+	public boolean performOk() {
+		savePreferences();
+		AgentController.instance().refreshCustomAgents();
+		return super.performOk();
+	}
+
+	@Override
+	public boolean performCancel() {
+		return super.performCancel();
+	}
+
+	@Override
+	protected void performDefaults() {
+		agentConfigs = new JsonArray();
+		refreshTable();
+		updateEnablement();
+		statusText.setText("");
+	}
+
+	@Override
+	public void dispose() {
+		super.dispose();
+		AgentController.instance().removeAgentListener(this);
+	}
+
+	@Override
+	public void agentStarted(IAgentService service) {
+		if (service instanceof CustomAgentService) {
+			Activator.getDisplay().asyncExec(new Runnable() {
+				@Override
+				public void run() {
+					if (!agentTable.isDisposed()) {
+						updateEnablement();
+						updateStatus();
+					}
+				}
+			});
+		}
+	}
+
+	@Override
+	public void agentStopped(IAgentService service) {
+		if (service instanceof CustomAgentService) {
+			Activator.getDisplay().asyncExec(new Runnable() {
+				@Override
+				public void run() {
+					if (!agentTable.isDisposed()) {
+						updateEnablement();
+						updateStatus();
+					}
+				}
+			});
+		}
+	}
+
+	@Override
+	public void agentScheduled(IAgentService service) {
+		if (service instanceof CustomAgentService) {
+			Activator.getDisplay().asyncExec(new Runnable() {
+				@Override
+				public void run() {
+					if (!agentTable.isDisposed()) {
+						updateEnablement();
+						updateStatus();
+					}
+				}
+			});
+		}
+	}
+
+	@Override
+	public void agentFailed(IAgentService service) {
+		if (service instanceof CustomAgentService) {
+			Activator.getDisplay().asyncExec(new Runnable() {
+				@Override
+				public void run() {
+					if (!agentTable.isDisposed()) {
+						updateEnablement();
+						updateStatus();
+					}
+				}
+			});
+		}
+	}
+}

--- a/org.eclipse.agents/src/org/eclipse/agents/preferences/CustomAgentDialog.java
+++ b/org.eclipse.agents/src/org/eclipse/agents/preferences/CustomAgentDialog.java
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.agents.preferences;
+
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.TitleAreaDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.DirectoryDialog;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+public class CustomAgentDialog extends TitleAreaDialog {
+
+	private Text nameText;
+	private Text commandText;
+	private Text workingDirText;
+
+	private String name = "";
+	private String command = "";
+	private String workingDirectory = "";
+
+	public CustomAgentDialog(Shell parentShell) {
+		super(parentShell);
+	}
+
+	public CustomAgentDialog(Shell parentShell, String name, String command, String workingDirectory) {
+		super(parentShell);
+		this.name = name != null ? name : "";
+		this.command = command != null ? command : "";
+		this.workingDirectory = workingDirectory != null ? workingDirectory : "";
+	}
+
+	@Override
+	public void create() {
+		super.create();
+		setTitle("Custom Agent Configuration");
+		setMessage("Configure a custom ACP agent by specifying its name and startup command.");
+		validate();
+	}
+
+	@Override
+	protected Control createDialogArea(Composite parent) {
+		Composite area = (Composite) super.createDialogArea(parent);
+
+		Composite container = new Composite(area, SWT.NONE);
+		container.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		GridLayout layout = new GridLayout(3, false);
+		container.setLayout(layout);
+
+		// Name field
+		Label nameLabel = new Label(container, SWT.NONE);
+		nameLabel.setText("Name:");
+		nameLabel.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
+
+		nameText = new Text(container, SWT.SINGLE | SWT.BORDER);
+		nameText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
+		nameText.setText(name);
+		nameText.addModifyListener(new ModifyListener() {
+			@Override
+			public void modifyText(ModifyEvent e) {
+				validate();
+			}
+		});
+
+		// Command field
+		Label commandLabel = new Label(container, SWT.NONE);
+		commandLabel.setText("Startup Command:");
+		commandLabel.setLayoutData(new GridData(SWT.BEGINNING, SWT.BEGINNING, false, false, 3, 1));
+
+		commandText = new Text(container, SWT.MULTI | SWT.BORDER | SWT.V_SCROLL);
+		GridData commandGd = new GridData(SWT.FILL, SWT.FILL, true, true, 3, 1);
+		commandGd.heightHint = 80;
+		commandText.setLayoutData(commandGd);
+		commandText.setText(command);
+		commandText.setToolTipText("Enter the startup command, one argument per line");
+		commandText.addModifyListener(new ModifyListener() {
+			@Override
+			public void modifyText(ModifyEvent e) {
+				validate();
+			}
+		});
+
+		// Working Directory field
+		Label workDirLabel = new Label(container, SWT.NONE);
+		workDirLabel.setText("Working Directory:");
+		workDirLabel.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
+
+		workingDirText = new Text(container, SWT.SINGLE | SWT.BORDER);
+		workingDirText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+		workingDirText.setText(workingDirectory);
+		workingDirText.setToolTipText("Optional working directory for the agent process");
+
+		Button browseButton = new Button(container, SWT.PUSH);
+		browseButton.setText("Browse...");
+		browseButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				DirectoryDialog dialog = new DirectoryDialog(getShell());
+				dialog.setText("Select Working Directory");
+				if (!workingDirText.getText().isEmpty()) {
+					dialog.setFilterPath(workingDirText.getText());
+				}
+				String selected = dialog.open();
+				if (selected != null) {
+					workingDirText.setText(selected);
+				}
+			}
+		});
+
+		return area;
+	}
+
+	private void validate() {
+		Button okButton = getButton(IDialogConstants.OK_ID);
+		if (okButton == null) {
+			return;
+		}
+
+		String nameValue = nameText.getText().trim();
+		String commandValue = commandText.getText().trim();
+
+		if (nameValue.isEmpty()) {
+			setErrorMessage("Name must not be empty");
+			okButton.setEnabled(false);
+			return;
+		}
+
+		if (commandValue.isEmpty()) {
+			setErrorMessage("Startup command must not be empty");
+			okButton.setEnabled(false);
+			return;
+		}
+
+		setErrorMessage(null);
+		okButton.setEnabled(true);
+	}
+
+	@Override
+	protected void okPressed() {
+		name = nameText.getText().trim();
+		command = commandText.getText().trim();
+		// Normalize line endings
+		command = command.replaceAll("\r\n", "\n");
+		workingDirectory = workingDirText.getText().trim();
+		super.okPressed();
+	}
+
+	public String getAgentName() {
+		return name;
+	}
+
+	public String getCommand() {
+		return command;
+	}
+
+	public String getWorkingDirectory() {
+		return workingDirectory;
+	}
+}

--- a/org.eclipse.agents/src/org/eclipse/agents/preferences/IPreferenceConstants.java
+++ b/org.eclipse.agents/src/org/eclipse/agents/preferences/IPreferenceConstants.java
@@ -31,4 +31,6 @@ public interface IPreferenceConstants {
 	
 	public static final String P_ACP_GEMINI_VERSION= Activator.PLUGIN_ID + ".default.acp.gemini.version"; //$NON-NLS-1$
 
+	public static final String P_ACP_CUSTOM_AGENTS = Activator.PLUGIN_ID + ".default.acp.custom.agents"; //$NON-NLS-1$
+
 }

--- a/org.eclipse.agents/src/org/eclipse/agents/preferences/PreferenceInitializer.java
+++ b/org.eclipse.agents/src/org/eclipse/agents/preferences/PreferenceInitializer.java
@@ -34,6 +34,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer impleme
 		store.setDefault(P_ACP_FILE_READ, true);
 		store.setDefault(P_ACP_FILE_WRITE, true);
 		store.setDefault(P_ACP_PROMPT4MCP, true);
+		store.setDefault(P_ACP_CUSTOM_AGENTS, "[]");
 
 		for (IAgentService service: AgentController.instance().getAgents()) {
 			if (service instanceof AbstractService) {

--- a/org.eclipse.agents/src/org/eclipse/agents/services/agent/CustomAgentService.java
+++ b/org.eclipse.agents/src/org/eclipse/agents/services/agent/CustomAgentService.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.agents.services.agent;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class CustomAgentService extends AbstractService {
+
+	private final String id;
+	private final String name;
+	private final String[] command;
+	private final String workingDirectory;
+
+	public CustomAgentService(String id, String name, String[] command, String workingDirectory) {
+		this.id = id;
+		this.name = name;
+		this.command = command;
+		this.workingDirectory = workingDirectory;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public String getFolderName() {
+		return "custom-" + id;
+	}
+
+	@Override
+	public String[] getDefaultStartupCommand() {
+		return command;
+	}
+
+	@Override
+	public void checkForUpdates(IProgressMonitor monitor) throws IOException {
+		// No-op for custom agents
+	}
+
+	@Override
+	public Process createProcess() throws IOException {
+		String[] startup = getStartupCommand();
+
+		List<String> commandAndArgs = new ArrayList<String>();
+		for (String arg : startup) {
+			commandAndArgs.add(arg);
+		}
+
+		ProcessBuilder pb = new ProcessBuilder(commandAndArgs);
+		if (workingDirectory != null && !workingDirectory.isEmpty()) {
+			File workDir = new File(workingDirectory);
+			if (workDir.exists() && workDir.isDirectory()) {
+				pb.directory(workDir);
+			}
+		}
+		return pb.start();
+	}
+
+	public String getWorkingDirectory() {
+		return workingDirectory;
+	}
+}


### PR DESCRIPTION
Hi there,

I hope I'm not overstepping with this contribution — thank you for all the work you've put into this project!

I noticed that currently there's no way to add custom ACP agents beyond the built-in Gemini support. Other tools in this space (like Zed, neovim integrations, etc.) allow users to plug in their own agents, so I took a shot at implementing something similar here.

This adds a "Custom Agents" preference page where users can configure third-party ACP-compatible agents (like Claude Code, Goose, or others) by specifying a name, startup command, and optional working directory. The agents can be started/stopped from the preference page and will appear in the agent selector dropdown.

While testing with an agent that doesn't fully populate its capabilities response (returning null instead of boolean values), I ran into a NullPointerException during session initialization. Since the ACP spec seems to allow optional capability fields, I included a small fix that handles null Booleans gracefully using `Boolean.TRUE.equals()`.

I tried to follow the existing patterns in the codebase, but please let me know if anything needs adjustment, I'm happy to rework whatever doesn't fit.

Changes:

  - New preference page under Coding Agents → Agent Services → Custom Agents
  - CustomAgentService that extends AbstractService
  - Agent list now refreshes dynamically when the dropdown is opened
  - Fix NPE when sse() or loadSession() capabilities return null

Thanks for your time reviewing this!