### PR TITLE
Add Kiro agent support

### DIFF
--- a/org.eclipse.agents.test/src/org/eclipse/agents/test/plugin/AgentControllerTest.java
+++ b/org.eclipse.agents.test/src/org/eclipse/agents/test/plugin/AgentControllerTest.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.agents.test.plugin;
+
+import org.eclipse.agents.Tracer;
+import org.eclipse.agents.chat.controller.AgentController;
+import org.eclipse.agents.services.agent.GeminiService;
+import org.eclipse.agents.services.agent.IAgentService;
+import org.eclipse.agents.services.agent.KiroService;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/**
+ * Unit tests for AgentController registration.
+ * Tests verify that KiroService is properly registered alongside other agents.
+ * 
+ * Requirements validated:
+ * - 2.1: AgentController includes KiroService in agentServices array
+ * - 2.2: getAgents() returns array containing KiroService
+ * - 2.3: KiroService coexists with GeminiService
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+public class AgentControllerTest {
+
+    private AgentController agentController;
+
+    @BeforeAll
+    public void setup() {
+        // Disable tracing to avoid Eclipse runtime dependencies in unit tests
+        Tracer.disableTracing = true;
+        agentController = AgentController.instance();
+    }
+
+    /**
+     * Test that KiroService is in the getAgents() array.
+     * Validates: Requirements 2.1, 2.2
+     */
+    @Test
+    public void testKiroServiceIsRegistered() {
+        IAgentService[] agents = agentController.getAgents();
+        boolean foundKiro = false;
+        
+        for (IAgentService agent : agents) {
+            if (agent instanceof KiroService) {
+                foundKiro = true;
+                break;
+            }
+        }
+        
+        Assert.assertTrue("KiroService should be registered in AgentController", foundKiro);
+    }
+
+    /**
+     * Test that GeminiService is still in the getAgents() array.
+     * Validates: Requirement 2.3
+     */
+    @Test
+    public void testGeminiServiceIsRegistered() {
+        IAgentService[] agents = agentController.getAgents();
+        boolean foundGemini = false;
+        
+        for (IAgentService agent : agents) {
+            if (agent instanceof GeminiService) {
+                foundGemini = true;
+                break;
+            }
+        }
+        
+        Assert.assertTrue("GeminiService should be registered in AgentController", foundGemini);
+    }
+
+    /**
+     * Test that both GeminiService and KiroService coexist in the agents array.
+     * Validates: Requirement 2.3
+     */
+    @Test
+    public void testBothServicesCoexist() {
+        IAgentService[] agents = agentController.getAgents();
+        boolean foundKiro = false;
+        boolean foundGemini = false;
+        
+        for (IAgentService agent : agents) {
+            if (agent instanceof KiroService) {
+                foundKiro = true;
+            }
+            if (agent instanceof GeminiService) {
+                foundGemini = true;
+            }
+        }
+        
+        Assert.assertTrue("Both KiroService and GeminiService should coexist", 
+                foundKiro && foundGemini);
+    }
+
+    /**
+     * Test that getAgents() returns at least 2 agents.
+     * Validates: Requirements 2.1, 2.2, 2.3
+     */
+    @Test
+    public void testAgentsArrayHasAtLeastTwoAgents() {
+        IAgentService[] agents = agentController.getAgents();
+        Assert.assertTrue("getAgents() should return at least 2 agents", 
+                agents.length >= 2);
+    }
+}

--- a/org.eclipse.agents.test/src/org/eclipse/agents/test/plugin/KiroServiceTest.java
+++ b/org.eclipse.agents.test/src/org/eclipse/agents/test/plugin/KiroServiceTest.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.agents.test.plugin;
+
+import java.io.File;
+
+import org.eclipse.agents.Tracer;
+import org.eclipse.agents.services.agent.AbstractService;
+import org.eclipse.agents.services.agent.IAgentService;
+import org.eclipse.agents.services.agent.KiroService;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+/**
+ * Unit tests for KiroService.
+ * Tests verify the basic identity and configuration methods of the service.
+ * 
+ * Requirements validated:
+ * - 1.1: KiroService extends AbstractService
+ * - 1.2: getName() returns "Kiro"
+ * - 1.3: getId() returns "kiro"
+ * - 1.4: getFolderName() returns "kiro"
+ * - 1.5: getDefaultStartupCommand() returns expected array
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+public class KiroServiceTest {
+
+    private KiroService kiroService;
+
+    @BeforeAll
+    public void setup() {
+        // Disable tracing to avoid Eclipse runtime dependencies in unit tests
+        Tracer.disableTracing = true;
+        kiroService = new KiroService();
+    }
+
+    /**
+     * Test that KiroService extends AbstractService.
+     * Validates: Requirement 1.1
+     */
+    @Test
+    public void testKiroServiceExtendsAbstractService() {
+        Assert.assertTrue("KiroService should extend AbstractService",
+                kiroService instanceof AbstractService);
+    }
+
+    /**
+     * Test that KiroService implements IAgentService.
+     * Validates: Requirement 1.1
+     */
+    @Test
+    public void testKiroServiceImplementsIAgentService() {
+        Assert.assertTrue("KiroService should implement IAgentService",
+                kiroService instanceof IAgentService);
+    }
+
+    /**
+     * Test that getName() returns "Kiro".
+     * Validates: Requirement 1.2
+     */
+    @Test
+    public void testGetNameReturnsKiro() {
+        Assert.assertEquals("getName() should return 'Kiro'",
+                "Kiro", kiroService.getName());
+    }
+
+    /**
+     * Test that getId() returns "kiro".
+     * Validates: Requirement 1.3
+     */
+    @Test
+    public void testGetIdReturnsKiro() {
+        Assert.assertEquals("getId() should return 'kiro'",
+                "kiro", kiroService.getId());
+    }
+
+    /**
+     * Test that getFolderName() returns "kiro".
+     * Validates: Requirement 1.4
+     */
+    @Test
+    public void testGetFolderNameReturnsKiro() {
+        Assert.assertEquals("getFolderName() should return 'kiro'",
+                "kiro", kiroService.getFolderName());
+    }
+
+    /**
+     * Test that getDefaultStartupCommand() returns the expected command array.
+     * Validates: Requirement 1.5
+     */
+    @Test
+    public void testGetDefaultStartupCommandReturnsExpectedArray() {
+        String userHome = System.getProperty("user.home");
+        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        String expectedPath;
+        if (isWindows) {
+            expectedPath = userHome + File.separator + ".kiro" + File.separator + "bin" + File.separator + "kiro-cli.exe";
+        } else {
+            expectedPath = userHome + "/.local/bin/kiro-cli";
+        }
+        String[] expected = new String[] { expectedPath, "acp" };
+        String[] actual = kiroService.getDefaultStartupCommand();
+        
+        Assert.assertArrayEquals("getDefaultStartupCommand() should return expected array",
+                expected, actual);
+    }
+
+    /**
+     * Test that getDefaultStartupCommand() returns an array with exactly 2 elements.
+     * Validates: Requirement 1.5
+     */
+    @Test
+    public void testGetDefaultStartupCommandHasTwoElements() {
+        String[] command = kiroService.getDefaultStartupCommand();
+        Assert.assertEquals("getDefaultStartupCommand() should return array with 2 elements",
+                2, command.length);
+    }
+
+    /**
+     * Test that getDefaultStartupCommand() second element is "acp".
+     * Validates: Requirement 1.5
+     */
+    @Test
+    public void testGetDefaultStartupCommandSecondElementIsAcp() {
+        String[] command = kiroService.getDefaultStartupCommand();
+        Assert.assertEquals("Second element should be 'acp'",
+                "acp", command[1]);
+    }
+}

--- a/org.eclipse.agents/plugin.xml
+++ b/org.eclipse.agents/plugin.xml
@@ -31,6 +31,8 @@
 			id="org.eclipse.agents.keyword.google" />
 		<keyword label="GEMINI"
 			id="org.eclipse.agents.keyword.gemini" />
+		<keyword label="KIRO"
+			id="org.eclipse.agents.keyword.kiro" />
 	</extension>
 
 	<extension point="org.eclipse.ui.activities">
@@ -128,6 +130,23 @@
 			<keywordReference id="org.eclipse.agents.keyword.chat" />
 			<keywordReference id="org.eclipse.agents.keyword.google" />
 			<keywordReference id="org.eclipse.agents.keyword.gemini" />
+		</page>
+		<page
+			id="org.eclipse.agents.preferences.services.kiro"
+			name="Kiro"
+			category="org.eclipse.agents.preferences.services"
+			class="org.eclipse.agents.preferences.AcpKiroPreferencePage">
+			<keywordReference id="org.eclipse.agents.keyword.mcp" />
+			<keywordReference id="org.eclipse.agents.keyword.acp" />
+			<keywordReference id="org.eclipse.agents.keyword.model" />
+			<keywordReference id="org.eclipse.agents.keyword.agent" />
+			<keywordReference id="org.eclipse.agents.keyword.client" />
+			<keywordReference id="org.eclipse.agents.keyword.context" />
+			<keywordReference id="org.eclipse.agents.keyword.protocol" />
+			<keywordReference id="org.eclipse.agents.keyword.coding" />
+			<keywordReference id="org.eclipse.agents.keyword.cli" />
+			<keywordReference id="org.eclipse.agents.keyword.chat" />
+			<keywordReference id="org.eclipse.agents.keyword.kiro" />
 		</page>
 	</extension>
 

--- a/org.eclipse.agents/src/org/eclipse/agents/chat/controller/AgentController.java
+++ b/org.eclipse.agents/src/org/eclipse/agents/chat/controller/AgentController.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.agents.services.agent.GeminiService;
 import org.eclipse.agents.services.agent.IAgentService;
+import org.eclipse.agents.services.agent.KiroService;
 import org.eclipse.agents.services.protocol.AcpSchema.AgentNotification;
 import org.eclipse.agents.services.protocol.AcpSchema.AgentRequest;
 import org.eclipse.agents.services.protocol.AcpSchema.AgentResponse;
@@ -69,7 +70,8 @@ public class AgentController {
 	IAgentService[] agentServices;
 	private AgentController() {
 		agentServices = new IAgentService[] { 
-			new GeminiService()
+			new GeminiService(),
+			new KiroService()
 //			new GooseService()
 		};
 		agentListeners = new ListenerList<IAgentServiceListener>();

--- a/org.eclipse.agents/src/org/eclipse/agents/preferences/AcpKiroPreferencePage.java
+++ b/org.eclipse.agents/src/org/eclipse/agents/preferences/AcpKiroPreferencePage.java
@@ -1,0 +1,285 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.agents.preferences;
+
+import org.eclipse.agents.Activator;
+import org.eclipse.agents.chat.controller.AgentController;
+import org.eclipse.agents.chat.controller.IAgentServiceListener;
+import org.eclipse.agents.services.agent.IAgentService;
+import org.eclipse.agents.services.agent.KiroService;
+import org.eclipse.agents.services.protocol.AcpSchema.InitializeResponse;
+import org.eclipse.agents.services.protocol.AcpSchema.McpCapabilities;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferencePage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ * Preference page for configuring Kiro CLI agent settings.
+ * Provides UI for startup command configuration and agent lifecycle control.
+ */
+public class AcpKiroPreferencePage extends PreferencePage implements 
+        IAgentServiceListener, IWorkbenchPreferencePage, SelectionListener {
+
+    private Composite parent;
+    private final String kiroPreferenceId;
+    
+    // Startup command
+    private Text startupCommandText;
+    
+    // Runtime controls
+    private Button startButton;
+    private Button stopButton;
+    private Text statusText;
+
+    public AcpKiroPreferencePage() {
+        super();
+        kiroPreferenceId = new KiroService().getStartupCommandPreferenceId();
+    }
+
+    @Override
+    protected Control createContents(Composite ancestor) {
+        parent = new Composite(ancestor, SWT.NONE);
+        GridLayout layout = new GridLayout();
+        layout.numColumns = 4;
+        layout.marginHeight = 0;
+        layout.marginWidth = 0;
+        parent.setLayout(layout);
+        parent.setLayoutData(new GridData());
+        
+        // Instructions
+        Label instructions = new Label(parent, SWT.WRAP);
+        instructions.setText("Configure Kiro CLI agent settings. Kiro is an AI coding assistant that communicates via ACP.");
+        GridData gd = new GridData(SWT.BEGINNING, SWT.BEGINNING, true, false, 4, 1);
+        gd.widthHint = convertWidthInCharsToPixels(80);
+        instructions.setLayoutData(gd);
+        
+        // Startup command label
+        Label label = new Label(parent, SWT.NONE);
+        label.setText("Startup Command:");
+        label.setLayoutData(new GridData(SWT.BEGINNING, SWT.BEGINNING, true, false, 4, 1));
+        
+        // Startup command text field
+        startupCommandText = new Text(parent, SWT.MULTI | SWT.BORDER);
+        startupCommandText.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false, 4, 1));
+        ((GridData)startupCommandText.getLayoutData()).minimumHeight = 30;
+
+        
+        // Start button
+        startButton = new Button(parent, SWT.PUSH);
+        startButton.setLayoutData(new GridData(SWT.BEGINNING, SWT.BEGINNING, false, false, 1, 1));
+        startButton.setText("Start");
+        startButton.addSelectionListener(this);
+        
+        // Stop button
+        stopButton = new Button(parent, SWT.PUSH);
+        stopButton.setLayoutData(new GridData(SWT.BEGINNING, SWT.BEGINNING, false, false, 1, 1));
+        stopButton.setText("Stop");
+        stopButton.addSelectionListener(this);
+        
+        // Spacer
+        new Label(parent, SWT.NONE).setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false, 2, 1));
+        
+        // Status label
+        Label statusLabel = new Label(parent, SWT.NONE);
+        statusLabel.setText("Status:");
+        statusLabel.setLayoutData(new GridData(SWT.BEGINNING, SWT.BEGINNING, true, false, 4, 1));
+        
+        // Status text field
+        statusText = new Text(parent, SWT.MULTI | SWT.BORDER | SWT.READ_ONLY);
+        statusText.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false, 4, 1));
+        ((GridData)statusText.getLayoutData()).minimumHeight = 100;
+        
+        PlatformUI.getWorkbench().getHelpSystem().setHelp(parent,
+                "org.eclipse.agents.preferences.AcpKiroPreferencePage");
+        
+        loadPreferences();
+        updateEnablement();
+        updateStatus();
+        
+        return parent;
+    }
+
+    @Override
+    public void init(IWorkbench workbench) {
+        setPreferenceStore(Activator.getDefault().getPreferenceStore());
+        AgentController.instance().addAgentListener(this);
+    }
+
+    private void updateEnablement() {
+        for (IAgentService service : AgentController.instance().getAgents()) {
+            if (service instanceof KiroService) {
+                if (!startButton.isDisposed() && !stopButton.isDisposed()) {
+                    startButton.setEnabled(!service.isRunning() && !service.isScheduled());
+                    stopButton.setEnabled(service.isRunning());
+                }
+            }
+        }
+    }
+
+    private void updateStatus() {
+        for (IAgentService service : AgentController.instance().getAgents()) {
+            if (service instanceof KiroService) {
+                if (service.isRunning() && service.getInitializeResponse() != null) {
+                    InitializeResponse response = service.getInitializeResponse();
+                    StringBuffer buffer = new StringBuffer();
+                    buffer.append("Kiro CLI Features:");
+                    
+                    buffer.append("\n  Load Prior Sessions: " + response.agentCapabilities().loadSession());
+                    buffer.append("\n  Prompt Capabilities: ");
+                    buffer.append("\n    Embedded Contexts: " + response.agentCapabilities().promptCapabilities().embeddedContext());
+                    buffer.append("\n    Audio: " + response.agentCapabilities().promptCapabilities().audio());
+                    buffer.append("\n    Images: " + response.agentCapabilities().promptCapabilities().image());
+                    
+                    McpCapabilities mcp = response.agentCapabilities().mcpCapabilities();
+                    buffer.append("\n  MCP Autoconfiguration: ");
+                    buffer.append("\n     MCP over SSE: " + (mcp == null ? false : mcp.sse()));
+                    buffer.append("\n     MCP over HTTP: " + (mcp == null ? false : mcp.http()));
+                    
+                    statusText.setText(buffer.toString());
+                    parent.layout(true);
+                    
+                } else if (service.isScheduled()) {
+                    statusText.setText("Starting");
+                } else {
+                    statusText.setText("Stopped");
+                }
+            }
+        }
+    }
+
+    private void loadPreferences() {
+        IPreferenceStore store = getPreferenceStore();
+        startupCommandText.setText(store.getString(kiroPreferenceId));
+    }
+
+    private void savePreferences() {
+        IPreferenceStore store = getPreferenceStore();
+        String preference = startupCommandText.getText();
+        // Sync carriage returns with what is used for parsing and default preferences
+        preference = preference.replaceAll("\r\n", "\n");
+        store.setValue(kiroPreferenceId, preference);
+    }
+
+    @Override
+    public boolean performCancel() {
+        return super.performCancel();
+    }
+
+    @Override
+    public boolean performOk() {
+        savePreferences();
+        return super.performOk();
+    }
+
+    @Override
+    protected void performDefaults() {
+        IPreferenceStore store = getPreferenceStore();
+        startupCommandText.setText(store.getDefaultString(kiroPreferenceId));
+    }
+
+    @Override
+    public void widgetDefaultSelected(SelectionEvent event) {
+        widgetSelected(event);
+    }
+
+    @Override
+    public void widgetSelected(SelectionEvent event) {
+        if (event.getSource() == startButton) {
+            for (IAgentService service : AgentController.instance().getAgents()) {
+                if (service instanceof KiroService) {
+                    service.schedule();
+                    updateEnablement();
+                }
+            }
+        } else if (event.getSource() == stopButton) {
+            for (IAgentService service : AgentController.instance().getAgents()) {
+                if (service instanceof KiroService) {
+                    service.stop();
+                    service.unschedule();
+                    updateEnablement();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+        AgentController.instance().removeAgentListener(this);
+    }
+
+    @Override
+    public void agentStopped(IAgentService service) {
+        if (service instanceof KiroService) {
+            Activator.getDisplay().asyncExec(new Runnable() {
+                @Override
+                public void run() {
+                    updateEnablement();
+                    updateStatus();
+                }
+            });
+        }
+    }
+
+    @Override
+    public void agentScheduled(IAgentService service) {
+        if (service instanceof KiroService) {
+            Activator.getDisplay().asyncExec(new Runnable() {
+                @Override
+                public void run() {
+                    updateEnablement();
+                    updateStatus();
+                }
+            });
+        }
+    }
+
+    @Override
+    public void agentStarted(IAgentService service) {
+        if (service instanceof KiroService) {
+            Activator.getDisplay().asyncExec(new Runnable() {
+                @Override
+                public void run() {
+                    updateEnablement();
+                    updateStatus();
+                }
+            });
+        }
+    }
+
+    @Override
+    public void agentFailed(IAgentService service) {
+        if (service instanceof KiroService) {
+            Activator.getDisplay().asyncExec(new Runnable() {
+                @Override
+                public void run() {
+                    updateEnablement();
+                    updateStatus();
+                }
+            });
+        }
+    }
+}

--- a/org.eclipse.agents/src/org/eclipse/agents/services/agent/KiroService.java
+++ b/org.eclipse.agents/src/org/eclipse/agents/services/agent/KiroService.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.agents.services.agent;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.agents.Tracer;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+/**
+ * Agent service implementation for Kiro CLI.
+ * Kiro is an AI coding assistant that communicates via the Agent Client Protocol (ACP).
+ * Unlike GeminiService, KiroService does not manage installation or updates since
+ * Kiro CLI is installed and managed externally.
+ */
+public class KiroService extends AbstractService {
+
+    @Override
+    public String getName() {
+        return "Kiro";
+    }
+
+    @Override
+    public String getId() {
+        return "kiro";
+    }
+
+    @Override
+    public String getFolderName() {
+        return "kiro";
+    }
+
+    @Override
+    public String[] getDefaultStartupCommand() {
+        return new String[] { getKiroCliPath(), "acp" };
+    }
+
+    /**
+     * Returns the default path to the Kiro CLI executable.
+     * Uses the standard installation location based on the operating system:
+     * - Windows: %USERPROFILE%\.kiro\bin\kiro-cli.exe
+     * - macOS/Linux: ~/.local/bin/kiro-cli
+     */
+    private String getKiroCliPath() {
+        String userHome = System.getProperty("user.home");
+        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        
+        if (isWindows) {
+            return userHome + File.separator + ".kiro" + File.separator + "bin" + File.separator + "kiro-cli.exe";
+        } else {
+            return userHome + "/.local/bin/kiro-cli";
+        }
+    }
+
+    @Override
+    public Process createProcess() throws IOException {
+        String[] startup = getStartupCommand();
+        Tracer.trace().trace(Tracer.ACP, String.join(", ", startup));
+        ProcessBuilder pb = new ProcessBuilder(startup);
+        return pb.start();
+    }
+
+    @Override
+    public void checkForUpdates(IProgressMonitor monitor) throws IOException {
+        // Kiro CLI is externally managed - no automatic updates required
+    }
+}


### PR DESCRIPTION
- Add KiroService extending AbstractService for Kiro CLI integration
- Add AcpKiroPreferencePage for Kiro-specific settings
- Register KiroService in AgentController
- Add Kiro keyword and preference page to plugin.xml
- Support both Windows and macOS/Linux CLI paths
- Add unit tests for KiroService and AgentController registration